### PR TITLE
patch: fix finding of ctypes

### DIFF
--- a/snap/local/patch-ctypes.sh
+++ b/snap/local/patch-ctypes.sh
@@ -3,9 +3,9 @@
 set -e
 set -x
 
-CTYPES_INIT=${SNAPCRAFT_PART_INSTALL}`python3 -c 'import ctypes; print(ctypes.__file__)'`
+CTYPES_INIT=`python3 -c 'import ctypes; print(ctypes.__file__)'`
 CTYPES_INIT_ORIG=${CTYPES_INIT}.orig
-SITE_PY=${SNAPCRAFT_PART_INSTALL}`python3 -c 'import site; print(site.__file__)'`
+SITE_PY=`python3 -c 'import site; print(site.__file__)'`
 
 # Restore patched files
 [ -f "patched/ctypes/__init__.py.orig" ] && mv "patched/ctypes/__init__.py.orig" "${CTYPES_INIT}"


### PR DESCRIPTION
The previous version worked with Snapcraft 7.3.2 because it was using the Python interpreter from the base, which shouldn't be done for classic snaps and fails in Snapcraft 7.4. With the inclusion of the python3.10-minimal package, the bundled Python is found and so the concatenation of ${SNAPCRAFT_PART_INSTALL} with the output of `python3 -c 'import ctypes; print(ctypes.__file__)'` is no longer needed - the result of that command is already inside the part's install dir.